### PR TITLE
Support non sequence overlap

### DIFF
--- a/data/data_loader.py
+++ b/data/data_loader.py
@@ -188,6 +188,13 @@ class MirDataProcessor:
 
                 if self.overlap_sequence:
                     num_samples = song_features.shape[0] - self.seq_length + 1
+
+                    if num_samples <= 0:
+                        print(
+                            f"Song {song_id} has insufficient data for seq_length {self.seq_length}, skipping."
+                        )
+                        continue
+                    
                     for i in range(num_samples):
                         X_seq = song_features[i : i + self.seq_length, :]
                         y_seq = song_labels[
@@ -228,9 +235,7 @@ class MirDataProcessor:
 
                     track_y_seqs = song_labels.reshape((num_samples, self.seq_length))
                     if self.use_median:
-                        track_y_seqs = track_y_seqs[
-                            :, self.seq_length // 2
-                        ]  # center label
+                        track_y_seqs = track_y_seqs[:, self.seq_length // 2]  # center label
                         y_sequences.append(track_y_seqs)
                     # Use mode otherwise
                     else:

--- a/notebooks/chroma_transformer/choma_transformer.ipynb
+++ b/notebooks/chroma_transformer/choma_transformer.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,17 +29,25 @@
     "from pathlib import Path\n",
     "from solver import Solver\n",
     "from griddy.griddy_tuna import hit_griddy, SearchMethod\n",
-    "from models.CRNN import CRNNModel\n",
     "from models.ChromaTransformer import ChromaTransformerModel\n",
     "from data.data_loader import MirDataProcessor\n",
-    "from utils.model_utils import get_device"
+    "from utils.model_utils import get_device\n",
+    "from solver import TrialMetric"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Device is cuda\n"
+     ]
+    }
+   ],
    "source": [
     "device = get_device()\n",
     "print(f\"Device is {device}\")"
@@ -49,21 +57,32 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Preparing model data...\n",
+      "Loading the combined CSV file...\n",
+      "Separating song IDs, features, and labels...\n",
+      "Scaling features using MinMaxScaler...\n",
+      "Encoding labels using LabelEncoder...\n",
+      "Saving the scaler to c:\\Users\\maxwe\\OneDrive\\Documents\\amadeus-ex-machina\\data\\processed\\scaler.pkl...\n",
+      "Saving the label encoder to c:\\Users\\maxwe\\OneDrive\\Documents\\amadeus-ex-machina\\data\\processed\\label_encoder.pkl...\n",
+      "Creating sequences of chromagram data within song boundaries...\n",
+      "Splitting data into training and testing sets...\n",
+      "Data preparation complete.\n",
+      "Number of classes determined: 976\n",
+      "Creating TensorDatasets for training and testing data...\n",
+      "Creating DataLoaders for training and testing datasets...\n",
+      "Data loaders are ready for training and testing.\n"
+     ]
+    }
+   ],
    "source": [
-    "# If you have already ran the downloader, change the value of download to False\n",
-    "download = False\n",
-    "\n",
-    "seq_length = 16\n",
-    "# Download and build useable train/test data out of the MIR Billboard dataset\n",
-    "data_processer = MirDataProcessor(output_dir=\"data\", download=download, batch_size=64, seq_length=seq_length, process_sequential=True)\n",
-    "if download:\n",
-    "    data_processer.process_billboard_data()\n",
-    "\n",
-    "# Create data loeaders for train and test set\n",
-    "train_loader, test_loader, num_classes = data_processer.build_data_loaders(device=device, nrows=2000) # nrows set to shrink dataset for testing\n",
-    "\n",
-    "print(f\"Number of classes: {num_classes}\")"
+    "# Initialize the data processor and create data loaders\n",
+    "data_processor = MirDataProcessor(batch_size=256, process_sequential=True, seq_length=16, overlap_sequence=True, use_median=True)\n",
+    "train_loader, test_loader, num_classes = data_processor.build_data_loaders(device=\"cuda\")"
    ]
   },
   {
@@ -77,9 +96,9 @@
     "SOLVER_PARAMS = {\n",
     "    Solver : {\n",
     "        \"device\": device,\n",
-    "        \"batch_size\": 64,\n",
-    "        \"epochs\": 2,\n",
-    "        \"early_stop_epochs\": 0, # early stop after n epochs without improvement, 0 to disable\n",
+    "        \"batch_size\": 256,\n",
+    "        \"epochs\": [5, 10],\n",
+    "        \"early_stop_epochs\": 3, # early stop after n epochs without improvement, 0 to disable\n",
     "        \"warmup_epochs\": 0, # 0 to disable\n",
     "        \"dtype\": \"float16\",\n",
     "        \"train_dataloader\": train_loader, # must be DataLoader object\n",
@@ -91,8 +110,11 @@
     "MODEL_PARAMS = {\n",
     "    ChromaTransformerModel: {\n",
     "        \"input_dim\": [24],\n",
-    "        \"seq_length\": [seq_length],\n",
+    "        \"seq_length\": [16],\n",
     "        \"num_classes\": [num_classes],\n",
+    "        \"dim_feedworward\": [256, 512, 1024],\n",
+    "        \"d_model\": [128, 256],\n",
+    "        \"num_layers\": [4, 6]\n",
     "    }\n",
     "}\n",
     "\n",
@@ -103,7 +125,7 @@
     "        \"weight_decay\": [0.00001],\n",
     "    },\n",
     "    torch.optim.Adam : {\n",
-    "        \"lr\": [0.03, 0.02, 0.01, 0.1], # this will auto-search as CATEGORICAL\n",
+    "        \"lr\": [0.008, 0.005, 0.001], # this will auto-search as CATEGORICAL\n",
     "    }\n",
     "}\n",
     "\n",
@@ -134,15 +156,97 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\"Hitting the griddy...\" -Ellie\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[I 2024-12-08 17:46:29,229] A new study created in RDB with name: chroma_transformer\n",
+      "c:\\Users\\maxwe\\OneDrive\\Documents\\amadeus-ex-machina\\griddy\\griddy_tuna.py:127: FutureWarning: suggest_loguniform has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use suggest_float(..., log=True) instead.\n",
+      "  return trial.suggest_loguniform(name, min(values), max(values))\n",
+      "c:\\Users\\maxwe\\OneDrive\\Documents\\amadeus-ex-machina\\griddy\\griddy_tuna.py:125: FutureWarning: suggest_uniform has been deprecated in v3.0.0. This feature will be removed in v6.0.0. See https://github.com/optuna/optuna/releases/tag/v3.0.0. Use suggest_float instead.\n",
+      "  return trial.suggest_uniform(name, min(values), max(values))\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----------------------------------\n",
+      "Epoch 1\n",
+      "-----------------------------------\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "043aacab14514f208d62c0fc561578f2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Training:   0%|          | 0/12893 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training Loss: 1.8452. Validation Loss: 1.4233.\n",
+      "Training Accuracy: 0.5426. Validation Accuracy: 0.6201.\n",
+      "-----------------------------------\n",
+      "Epoch 2\n",
+      "-----------------------------------\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\maxwe\\anaconda3\\envs\\amadeus-ex-machina\\Lib\\site-packages\\torch\\optim\\lr_scheduler.py:152: UserWarning: The epoch parameter in `scheduler.step()` was not necessary and is being deprecated where possible. Please use `scheduler.step()` to step the scheduler. During the deprecation, if epoch is different from None, the closed form is used instead of the new chainable form, where available. Please open an issue if you are unable to replicate your use case: https://github.com/pytorch/pytorch/issues/new/choose.\n",
+      "  warnings.warn(EPOCH_DEPRECATION_WARNING, UserWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "da7c25ace8314c6d9bd13713900a7e55",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Training:   0%|          | 0/12893 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "my_study = \"chroma_transformer\"\n",
     "\n",
     "output_folder = Path(\"griddy\")\n",
     "\n",
-    "solver_reference = hit_griddy(my_study, param_set=PARAM_SET, out_dir=output_folder, n_trials=20, n_jobs=4, prune=False, resume=False)\n",
+    "solver_reference = hit_griddy(my_study, param_set=PARAM_SET, out_dir=output_folder, n_trials=30, n_jobs=1, prune=False, resume=False, trial_metric=TrialMetric.ACCURACY)\n",
     "# NOTE: modest values of n_trials and n_jobs set here for testing, set your values accordingly"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/solver.py
+++ b/solver.py
@@ -14,6 +14,7 @@ class TrialMetric(Enum):
     ACCURACY = 1
     # add more as needed
 
+
 class Solver:
     def __init__(
         self,
@@ -107,7 +108,9 @@ class Solver:
 
         return total_loss, avg_loss, accuracy
 
-    def train_and_evaluate(self, trial=None, trial_metric=TrialMetric.LOSS, plot_results=False):
+    def train_and_evaluate(
+        self, trial=None, trial_metric=TrialMetric.LOSS, plot_results=False
+    ):
         train_loader = self.train_dataloader
         valid_loader = self.valid_dataloader
 
@@ -219,7 +222,7 @@ class Solver:
 
         if plot_results:
             self.plot_curves(self.model.__class__.__name__)
-        
+
         match trial_metric:
             case TrialMetric.LOSS:
                 return best_loss


### PR DESCRIPTION
Allows for the data loader to process overlapping or non-overlapping sequences. Additionally, you can set a flag to use the mode or the median to get the chord annotation for the non overlapping sequences. 

That flag does nothing for the overlapping sequences because it caused the processing function to be INCREDIBLY slow, and I actually didn't get it to ever finish. Something could probably be done to fix that, but there are two factors there:

1. I'm tired of staring at that problem
2. Going larger than a sequence length of 16 is intractable for the overlapping sequences due to memory limitations. With how granular the chroma data is, it's unlike that the mode over the median will make any difference